### PR TITLE
fix(security): bump golang builder 1.25.0 -> 1.25.8 (CVE-2025-68121)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.0 as build
+FROM golang:1.25.8 as build
 
 RUN mkdir -p /go/src/go-exporter
 WORKDIR /go/src/go-exporter
@@ -9,4 +9,3 @@ COPY main.go .
 RUN go get germanedge.com/go-exporter
 
 RUN CGO_ENABLED=0 go build -a -installsuffix cgo --ldflags "-s -w" -o /usr/bin/go-exporter
-


### PR DESCRIPTION
Security fix for CVE-2025-68121 (CVSS 10.0 CRITICAL).

Bumps golang builder from 1.25.0 to 1.25.8 which contains the fix for the TLS resumed handshake bypass in Go stdlib crypto/tls.

No breaking changes — static binary build, builder image does not affect runtime behaviour.

Blast radius: go-exporter binary is embedded in ge-ubuntu (platform base). Every container inherits the fix once ge-ubuntu and downstream base images are bumped.