### PR TITLE
GE4-29345: fix(security): bump golang 1.25.8→1.25.9 (CVE-2026-27143, CVSS 9.8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8 as build
+FROM golang:1.25.9 as build
 
 RUN mkdir -p /go/src/go-exporter
 WORKDIR /go/src/go-exporter


### PR DESCRIPTION
## CVE-2026-27143 — Go compiler memory corruption (CVSS 9.8 CRITICAL)

**CVE**: CVE-2026-27143  
**CVSS**: 9.8 CRITICAL  
**Published**: 2026-04-08  
**SLA deadline**: 2026-04-10 (⚠️ 13 days overdue)

### Vulnerability

Arithmetic overflow on loop induction variables in the Go compiler — allows invalid memory indexing at runtime, potentially leading to memory corruption.

### Change

| File | Before | After |
|------|--------|-------|
| Dockerfile |  |  |

golang:1.25.9 was released 2026-04-22 and contains the fix.

### Impact

 compiles the  binary that is 'd into , which is the base for  (28 platform consumers). This is the first link in the fix chain:



### Related

- Jira: [GE4-29345](https://jira.germanedge.com/browse/GE4-29345) (master CVE-2026-27143 triage ticket)
- Downstream: ge-ubuntu and ge-ubuntu-generic PRs will follow after CI publishes new go-exporter image
